### PR TITLE
security: prevent reflected XSS via dict parameter (correction_form.php)

### DIFF
--- a/correction_form_app/correction_form.php
+++ b/correction_form_app/correction_form.php
@@ -92,7 +92,7 @@ onsubmit="submitted=true;">
    Leave 'name' field unchanged from the one originally used by Google
 */
  //$val = "<input type=\"text\" name=\"entry.1072768805\" value=\"$dict\" class=\"ss-q-short\" id=\"entry_1072768805\" dir=\"auto\" aria-label=\"Which Dictionary?  \" aria-required=\"true\" required=\"\" style=\"width:80px;position:relative;left:50px;\"  ></input>";
- $val = "<input type=\"text\" name=\"entry_dict\" value=\"$dict\" class=\"ss-q-short\" id=\"entry_dict\" dir=\"auto\" aria-label=\"Which Dictionary?  \" aria-required=\"true\" required=\"\" style=\"width:80px;position:relative;left:50px;\"  ></input>";
+ $val = "<input type=\"text\" name=\"entry_dict\" value=\"" . htmlspecialchars($dict, ENT_QUOTES) . "\" class=\"ss-q-short\" id=\"entry_dict\" dir=\"auto\" aria-label=\"Which Dictionary?  \" aria-required=\"true\" required=\"\" style=\"width:80px;position:relative;left:50px;\"  ></input>";
  echo $val;
 ?>
 <div class="error-message"></div>


### PR DESCRIPTION
## Reflected XSS via `dict` parameter

[`correction_form_app/correction_form.php`](https://github.com/sanskrit-lexicon/CORRECTIONS/blob/master/correction_form_app/correction_form.php) reflected the **raw** `$_GET['dict']` into an HTML attribute:

```php
$dict = $_GET['dict'];
...
$val = "<input ... value=\"$dict\" ...></input>";
echo $val;
```

`?dict="><script>alert(1)</script>` breaks out of the `value` attribute and executes arbitrary JavaScript.

## Fix

Escape at the output point with `htmlspecialchars($dict, ENT_QUOTES)`. `$dict` is intentionally left raw for the later `if ($dict == 'APES')` comparison (dictionary codes contain no HTML metacharacters, so behaviour is unchanged); only the HTML output is escaped.

`php -l` clean (PHP 8.2).

## Scope note

[`correction_form_response.php`](https://github.com/sanskrit-lexicon/CORRECTIONS/blob/master/correction_form_app/correction_form_response.php) was reviewed: it writes the POSTed fields to TSV files and does **not** reflect them back to the browser, so it is not a reflected-XSS sink.

Part of the org-wide reflected-XSS / JSONP sweep (sanskrit-lexicon/csl-websanlexicon#27, #63, #67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)