### PR TITLE
security: guard dict against array injection (is_string)

### DIFF
--- a/correction_form_app/correction_form.php
+++ b/correction_form_app/correction_form.php
@@ -5,7 +5,9 @@
     dict  A dictionary identifier
 */
  $dict = $_GET['dict'];
- if (!$dict) {$dict = '?';}
+ // Guard against array injection (?dict[]=x): htmlspecialchars() on an array
+ // would throw a TypeError. Coerce any non-string (or empty) value to '?'.
+ if (!is_string($dict) || !$dict) {$dict = '?';}
 
 ?>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">


### PR DESCRIPTION
Follow-up to [#444](https://github.com/sanskrit-lexicon/CORRECTIONS/pull/444).

## Problem

[`correction_form_app/correction_form.php`](https://github.com/sanskrit-lexicon/CORRECTIONS/blob/master/correction_form_app/correction_form.php) reads `$dict = $_GET['dict']`. A request like `?dict[]=x` makes it an **array**; `if (!$dict)` is **false** for a non-empty array, so the array flows into the `htmlspecialchars()` call added in #444:

```php
htmlspecialchars($dict, ENT_QUOTES)   // TypeError when $dict is an array (PHP 8)
```

That throws an uncaught **`TypeError`** → **HTTP 500** (instead of the previous harmless `Array` render). Not XSS, but an unauthenticated 500.

## Fix

Coerce any non-string (or empty) value to `'?'` before use:

```php
if (!is_string($dict) || !$dict) {$dict = '?';}
```

## Verification

- `php -l` clean (PHP 8.2).
- `?dict[]=x` → `$dict` becomes `'?'`, **no TypeError**.
- Valid dict codes (e.g. `MW`, `APES`) → unchanged (the later `== 'APES'` comparison still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)